### PR TITLE
Extend baffle thickness min/max to 30

### DIFF
--- a/BafflePlanner/Resources/UI/BafflePlanner.ui
+++ b/BafflePlanner/Resources/UI/BafflePlanner.ui
@@ -245,7 +245,7 @@
            <double>0.000000000000000</double>
           </property>
           <property name="maximum">
-           <double>10.000000000000000</double>
+           <double>30.000000000000000</double>
           </property>
           <property name="value">
            <double>0.000000000000000</double>
@@ -267,7 +267,7 @@
            <double>0.000000000000000</double>
           </property>
           <property name="maximum">
-           <double>10.000000000000000</double>
+           <double>30.000000000000000</double>
           </property>
           <property name="value">
            <double>0.000000000000000</double>


### PR DESCRIPTION
Ideally this range would be settable by the user interface,
but this extended range makes the planner more usable
in other contexts (e.g. a craniotomy for neurosurgery
planning) without much complexity while keeping the
slider usable for small thicknesses.