### PR TITLE
BUG: Fix range setters in EchoVolumeRender interface

### DIFF
--- a/EchoVolumeRender/EchoVolumeRender.py
+++ b/EchoVolumeRender/EchoVolumeRender.py
@@ -514,7 +514,7 @@ class EchoVolumeRenderLogic(ScriptedLoadableModuleLogic):
 
   @depthRange.setter
   def depthRange(self, valueRange):
-    self._setRenderingParameterValue("depthRange", value)
+    self._setRenderingParameterValue("depthRange", valueRange)
 
   @property
   def depthDarkening(self):
@@ -530,7 +530,7 @@ class EchoVolumeRenderLogic(ScriptedLoadableModuleLogic):
 
   @depthColoringRange.setter
   def depthColoringRange(self, valueRange):
-    self._setRenderingParameterValue("depthColoringRange", value)
+    self._setRenderingParameterValue("depthColoringRange", valueRange)
 
   @property
   def brightnessScale(self):


### PR DESCRIPTION
Resolves issue where depthRange and depthColoringRange properties in EchoVolumeRender public interface were not properly propagated to underlying shader.

Range values are currently set internally without referencing the public interface: https://github.com/SlicerHeart/SlicerHeart/blob/master/EchoVolumeRender/EchoVolumeRender.py#L57