### PR TITLE
BUG: Ensure UltrasoundImage3dReader sets DICOM.instanceUIDs

### DIFF
--- a/UltrasoundImage3dReader/UltrasoundImage3dReader.py
+++ b/UltrasoundImage3dReader/UltrasoundImage3dReader.py
@@ -191,6 +191,7 @@ class UltrasoundImage3dReaderFileReader(object):
       # retrieve ECG info
       ecg = source.GetECG()
       tableNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode", baseName+" ECG")
+      tableNode.SetAttribute("DICOM.instanceUIDs", slicer.dicomDatabase.instanceForFile(filePath))
       ecgSamples = self.safeArrayToNumpy(ecg.samples)
       numberOfSamples = len(ecgSamples)
       ecgTimestamps = np.arange(ecg.start_time, ecg.start_time+numberOfSamples*ecg.delta_time, ecg.delta_time)
@@ -208,6 +209,7 @@ class UltrasoundImage3dReaderFileReader(object):
 
       # set color table
       colorTableNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLColorTableNode", baseName+" colormap")
+      colorTableNode.SetAttribute("DICOM.instanceUIDs", slicer.dicomDatabase.instanceForFile(filePath))
       colorMapArray = source.GetColorMap()
       numberOfColors = len(colorMapArray)
       colorTableNode.SetTypeToUser()

--- a/UltrasoundImage3dReader/UltrasoundImage3dReader.py
+++ b/UltrasoundImage3dReader/UltrasoundImage3dReader.py
@@ -181,6 +181,8 @@ class UltrasoundImage3dReaderFileReader(object):
         tempVolumeNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", baseName)
         nodeForStoringMetadata = tempVolumeNode
 
+      nodeForStoringMetadata.SetAttribute("DICOM.instanceUIDs", slicer.dicomDatabase.instanceForFile(filePath))
+
       # retrieve probe info
       probe = source.GetProbeInfo()
       nodeForStoringMetadata.SetAttribute("SlicerHeart.ProbeName", probe.name)
@@ -224,6 +226,7 @@ class UltrasoundImage3dReaderFileReader(object):
         maxRes = np.ctypeslib.as_ctypes(np.array([maxDimension, maxDimension, maxDimension], dtype=np.ushort))
 
         frame = source.GetFrame(frameIndex, bbox, maxRes)
+        tempVolumeNode.SetAttribute("DICOM.instanceUIDs", slicer.dicomDatabase.instanceForFile(filePath))
         tempVolumeNode.SetAttribute("SlicerHeart.FrameFormat", str(frame.format))
         voxels = self.frameTo3dArray(frame)
         slicer.util.updateVolumeFromArray(tempVolumeNode, voxels)


### PR DESCRIPTION
This commit ensures that the scalar volume nodes associated with a sequence are also associated with the corresponding "DICOM.instanceUIDs"