### PR TITLE
ENH: Add unit test for AnnulusShapeAnalyzer

### DIFF
--- a/AnnulusShapeAnalyzer/AnnulusShapeAnalyzer.py
+++ b/AnnulusShapeAnalyzer/AnnulusShapeAnalyzer.py
@@ -1842,6 +1842,36 @@ class AnnulusShapeAnalyzerTest(ScriptedLoadableModuleTest):
                 zipObject.extractall(path=temp_dir)
 
             print(os.listdir(temp_dir))
-            # TODO: run tests with the folder
+
+            widget = slicer.modules.AnnulusShapeAnalyzerWidget
+            logic = widget.logic
+
+            # load annulus contour and calculate mean
+            widget.pathLineEdit_loadPopulationFile.currentPath = temp_dir + "/" + "0-1_AnnulusContourPoints.csv"
+            widget.onLoadPopulationFile()
+            widget.onProcessPopulationFile()
+            widget.onCalculateMeanShape()
+
+            # pca
+            widget.onEvaluateModels()
+
+            # load demographics and regress w.r.t. selected variable
+            widget.pathLineEdit_demographicsFilePath.currentPath = temp_dir + "/" + "Demographics.csv"
+            widget.onLoadAssociatedDemographics()
+            widget.tableWidget_demographics.findItems("bsa", qt.Qt.MatchExactly)[0].setCheckState(qt.Qt.Checked)
+            widget.onPerformRegressionOnSelectedVariables()
+
+            # compare curves
+            widget.comboBox_compareCurve2.currentIndex = 3
+            widget.onCompareCurves()
+
+            # strain and curvature
+            widget.comboBox_strainCurvatureDeformedPhase.currentIndex = 1
+            widget.onComputeStrainCurvature()
+
+            # cleanup
+            logic.clear()
+            widget.onReload()
+            slicer.mrmlScene.Clear()
 
         self.delayDisplay('Test passed')


### PR DESCRIPTION
@che85 
Currently using the 0-1_AnnulusContourPoints.csv as the annulus contour file for the unit test.

Some issues with the test dataset: 
L14-NM_HD_smooth in 1-5_AnnulusContourPoints.csv
L067-NM_SA_smooth in 9-13_AnnulusContourPoints.csv
L087-NM_SA_smooth and L100-NM_SA_smooth in 13-up_AnnulusContourPoints.csv
These filenames are not presented in the Demographics.csv and thus would fail the test in the regression section. We may want to fix this for the sample data if users want to try them manually. I haven't checked the all-age but it may have the same issue if it is just a concatenation of all the contour files.